### PR TITLE
Change details from Repositories to Failures

### DIFF
--- a/frontend/src/components/Dashboard.vue
+++ b/frontend/src/components/Dashboard.vue
@@ -10,10 +10,10 @@
         Healthy Repos
         <div class="result">{{ allPassed }}</div>
       </button>
-      <div class="content failed">
+      <button class="content failed state" v-on:click="hideRepos = !hideRepos">
         Failures
-        <div class="result">{{ failedRepo }}</div>
-      </div>
+        <div class="result">{{failedRepo}}</div>
+      </button>
     </div>
     <div v-if="!hideRepos">
       <Details />
@@ -101,7 +101,7 @@ export default {
 
 .state{
   &:hover{
-    background-color: #1C9FCE;
+    background-color:#E53E3E;
     color: white;
     }
 }

--- a/frontend/src/components/Dashboard.vue
+++ b/frontend/src/components/Dashboard.vue
@@ -2,10 +2,10 @@
   <div>
     <h1 class="header">CHECK MY REPO</h1>
     <div class="square">
-      <button class="content total state" v-on:click="hideRepos = !hideRepos">
+      <div class="content total">
         Repositories
         <div class="result">{{frontend.length}}</div>
-      </button>
+      </div>
       <button class="content passed state-healthy" v-on:click="hideHealthy = !hideHealthy">
         Healthy Repos
         <div class="result">{{ allPassed }}</div>


### PR DESCRIPTION
# A little adjustment to improve UX, instead of showing details when Repositories is pushed, is now available for Failures 