### PR TITLE
Add token to try to solve api rate limit on jobs

### DIFF
--- a/.github/workflows/daily-check.yml
+++ b/.github/workflows/daily-check.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Setup Node version
         uses: actions/setup-node@v1
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           node-version: '12'
 
       - name: Install dependencies

--- a/.github/workflows/lint-and-deploy-on-push-to-main.yml
+++ b/.github/workflows/lint-and-deploy-on-push-to-main.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Setup Node version
         uses: actions/setup-node@v1
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           node-version: '12'
 
       - name: Install dependencies


### PR DESCRIPTION
Workflows are being interrupted claiming API rate limit, this aim to fix that

> Issue : #

## Description
Following GitHub documentation and a thread in GitHub repo, adding the following line should solve it:
` with:
          repo-token: ${{ secrets.GITHUB_TOKEN }}`
